### PR TITLE
Updating the OAuth 2.0 Scope Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ nbdist/
 
 .mvn
 .DS_Store
+.vscode

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This microservice is designed to be used with other microservices. Please look a
 
 This microservice is configurable to be secured with an OAuth 2 provider.
 
-__Scopes__: This application uses the following scope: `combiner.*`
+__Scopes__: This application uses the following scope syntax: `fdns.combiner.{config}.{create|read|update|delete}`. Example: `fdns.combiner.myconfig.read`
 
 Please see the following environment variables for configuring with your OAuth 2 provider:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,10 @@
 version: '3.1'
 services:
-  mongo:
-    image: mongo
-    ports:
-      - "27017:27017"
   fluentd:
     image: fluent/fluentd
     ports:
       - "24224:24224"
-  fdns-ms-object:
-    image: cdcgov/fdns-ms-object
+  fdns-ms-stubbing:
+    image: cdcgov/fdns-ms-stubbing
     ports:
-      - "8083:8083"
-    environment:
-      OBJECT_PORT: 8083
+      - "3002:3002" 

--- a/src/main/java/gov/cdc/foundation/controller/CombinerController.java
+++ b/src/main/java/gov/cdc/foundation/controller/CombinerController.java
@@ -71,7 +71,6 @@ public class CombinerController {
 	@ResponseBody
 	public ResponseEntity<?> index() throws IOException {
 		ObjectMapper mapper = new ObjectMapper();
-		
 		Map<String, Object> log = new HashMap<>();
 		
 		try {
@@ -86,29 +85,60 @@ public class CombinerController {
 		}
 	}
 
-
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('combiner.'.concat(#config)) or #config.startsWith('public-')")
-	@RequestMapping(value = "config/{config}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Create or update rules for the specified configuration", notes = "Create or update configuration")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #config.startsWith('public-')"
+		+ " or #oauth2.hasScope('fdns.combiner.'.concat(#config).concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.combiner.'.concat(#config).concat('.update'))"
+		+ " or #oauth2.hasScope('fdns.combiner.'.concat(#config).concat('.*'))"
+		+ " or #oauth2.hasScope('fdns.combiner.*.create')"
+		+ " or #oauth2.hasScope('fdns.combiner.*.update')"
+		+ " or #oauth2.hasScope('fdns.combiner.*.*')"
+	)
+	@RequestMapping(
+		value = "config/{config}",
+		method = RequestMethod.PUT,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Create or update rules for the specified configuration",
+		notes = "Create or update configuration"
+	)
 	@ResponseBody
 	public ResponseEntity<?> upsertConfigWithPut(
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@RequestBody(required = true) String payload,
-			@ApiParam(value = "Configuration name") @PathVariable(value = "config") String config) {
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@RequestBody(required = true) String payload,
+		@ApiParam(value = "Configuration name") @PathVariable(value = "config") String config
+	) {
 		return upsertConfig(authorizationHeader, payload, config);
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('combiner.'.concat(#config)) or #config.startsWith('public-')")
-	@RequestMapping(value = "config/{config}", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Create or update rules for the specified configuration", notes = "Create or update configuration")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #config.startsWith('public-')"
+		+ " or #oauth2.hasScope('fdns.combiner.'.concat(#config).concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.combiner.'.concat(#config).concat('.update'))"
+		+ " or #oauth2.hasScope('fdns.combiner.'.concat(#config).concat('.*'))"
+		+ " or #oauth2.hasScope('fdns.combiner.*.create')"
+		+ " or #oauth2.hasScope('fdns.combiner.*.update')"
+		+ " or #oauth2.hasScope('fdns.combiner.*.*')"
+	)
+	@RequestMapping(
+		value = "config/{config}",
+		method = RequestMethod.POST,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Create or update rules for the specified configuration",
+		notes = "Create or update configuration"
+	)
 	@ResponseBody
 	public ResponseEntity<?> upsertConfig(
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@RequestBody(required = true) String payload, 
-			@ApiParam(value = "Configuration name") @PathVariable(value = "config") String config) {
-
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@RequestBody(required = true) String payload, 
+		@ApiParam(value = "Configuration name") @PathVariable(value = "config") String config
+	) {
 		ObjectMapper mapper = new ObjectMapper();
-
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_UPSERTCONFIG, config);
 
 		try {
@@ -138,16 +168,29 @@ public class CombinerController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('combiner.'.concat(#config)) or #config.startsWith('public-')")
-	@RequestMapping(value = "config/{config}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Get configuration", notes = "Get configuration")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #config.startsWith('public-')"
+		+ " or #oauth2.hasScope('fdns.combiner.'.concat(#config).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.combiner.'.concat(#config).concat('.*'))"
+		+ " or #oauth2.hasScope('fdns.combiner.*.read')"
+		+ " or #oauth2.hasScope('fdns.combiner.*.*')"
+	)
+	@RequestMapping(
+		value = "config/{config}",
+		method = RequestMethod.GET,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Get configuration",
+		notes = "Get configuration"
+	)
 	@ResponseBody
 	public ResponseEntity<?> getConfig(
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@ApiParam(value = "Configuration name") @PathVariable(value = "config") String config) {
-
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@ApiParam(value = "Configuration name") @PathVariable(value = "config") String config
+	) {
 		ObjectMapper mapper = new ObjectMapper();
-
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_GETCONFIG, config);
 
 		try {
@@ -165,16 +208,28 @@ public class CombinerController {
 
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('combiner.'.concat(#config)) or #config.startsWith('public-')")
-	@RequestMapping(value = "config/{config}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Delete configuration", notes = "Delete configuration")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.combiner.'.concat(#config).concat('.delete'))"
+		+ " or #oauth2.hasScope('fdns.combiner.'.concat(#config).concat('.*'))"
+		+ " or #oauth2.hasScope('fdns.combiner.*.delete')"
+		+ " or #oauth2.hasScope('fdns.combiner.*.*')"
+	)
+	@RequestMapping(
+		value = "config/{config}",
+		method = RequestMethod.DELETE,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Delete configuration",
+		notes = "Delete configuration"
+	)
 	@ResponseBody
 	public ResponseEntity<?> deleteConfig(
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@ApiParam(value = "Configuration name") @PathVariable(value = "config") String config) {
-
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@ApiParam(value = "Configuration name") @PathVariable(value = "config") String config
+	) {
 		ObjectMapper mapper = new ObjectMapper();
-
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_DELETECONFIG, config);
 
 		try {
@@ -194,20 +249,34 @@ public class CombinerController {
 
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('combiner.'.concat(#config)) or #config.startsWith('public-')")
-	@RequestMapping(method = RequestMethod.POST, value = "/{targetType}/{config}", produces = MediaType.TEXT_PLAIN_VALUE, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	@ApiOperation(value = "Export data to CSV or XLSX", notes = "Parse data and transform them to CSV or XLSX")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.combiner.'.concat(#config).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.combiner.'.concat(#config).concat('.*'))"
+		+ " or #oauth2.hasScope('fdns.combiner.*.read')"
+		+ " or #oauth2.hasScope('fdns.combiner.*.*')"
+	)
+	@RequestMapping(
+		method = RequestMethod.POST,
+		value = "/{targetType}/{config}",
+		produces = MediaType.TEXT_PLAIN_VALUE,
+		consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+	)
+	@ApiOperation(
+		value = "Export data to CSV or XLSX",
+		notes = "Parse data and transform them to CSV or XLSX"
+	)
 	@ResponseBody
 	public ResponseEntity<?> transform(
-			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-			@RequestPart("file") MultipartFile[] file,
-			@ApiParam(value = "Target Type", allowableValues = "csv,xlsx") @PathVariable(value = "targetType", required = true) String targetType,
-			@ApiParam(value = "Combiner Configuration") @PathVariable(value = "config", required = true) String config,
-			@ApiParam(value = "Filename expected") @RequestParam(value = "filename", required = false) String filename,
-			@ApiParam(value = "Orientation", allowableValues = "portrait,landscape", defaultValue = "portrait") @RequestParam(value = "orientation", required = false) String orientation, 
-			@ApiParam(value = "Include Header", defaultValue = "true") @RequestParam(value = "includeHeader", required = false) boolean includeHeader,
-			@ApiParam(value = "Sort file names", defaultValue = "false") @RequestParam(value = "sortFiles", required = false) boolean sortFiles) {
-
+		@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+		@RequestPart("file") MultipartFile[] file,
+		@ApiParam(value = "Target Type", allowableValues = "csv,xlsx") @PathVariable(value = "targetType", required = true) String targetType,
+		@ApiParam(value = "Combiner Configuration") @PathVariable(value = "config", required = true) String config,
+		@ApiParam(value = "Filename expected") @RequestParam(value = "filename", required = false) String filename,
+		@ApiParam(value = "Orientation", allowableValues = "portrait,landscape", defaultValue = "portrait") @RequestParam(value = "orientation", required = false) String orientation, 
+		@ApiParam(value = "Include Header", defaultValue = "true") @RequestParam(value = "includeHeader", required = false) boolean includeHeader,
+		@ApiParam(value = "Sort file names", defaultValue = "false") @RequestParam(value = "sortFiles", required = false) boolean sortFiles
+	) {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_COMBINE, config);
 
 		try {
@@ -271,15 +340,25 @@ public class CombinerController {
 		}
 	}
 
-	@RequestMapping(value = "/{targetType}/flatten", method = RequestMethod.POST)
-	@ApiOperation(value = "Flatten JSON object", notes = "Flatten a JSON object to JSON, CSV and XLSX")
+	@RequestMapping(
+		value = "/{targetType}/flatten",
+		method = RequestMethod.POST
+	)
+	@ApiOperation(
+		value = "Flatten JSON object",
+		notes = "Flatten a JSON object to JSON, CSV and XLSX"
+	)
 	@ResponseBody
-	public ResponseEntity<?> flatten(@RequestPart("file") MultipartFile file, @ApiParam(value = "Target Type", allowableValues = "json,csv,xlsx") @PathVariable(value = "targetType", required = true) String targetType) {
+	public ResponseEntity<?> flatten(
+		@RequestPart("file") MultipartFile file,
+		@ApiParam(value = "Target Type",
+		allowableValues = "json,csv,xlsx") @PathVariable(value = "targetType",
+		required = true) String targetType
+	) {
 		ObjectMapper mapper = new ObjectMapper();
-
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_FLATTEN, null);
-		try {
 
+		try {
 			if (!("json".equalsIgnoreCase(targetType) || "csv".equalsIgnoreCase(targetType) || "xlsx".equalsIgnoreCase(targetType)))
 				throw new ServiceException(MessageHelper.ERROR_INVALID_TARGET_TYPE);
 
@@ -329,10 +408,12 @@ public class CombinerController {
 		}
 	}
 
-	private Map<String, Map<String, String>> getAggregatedData(MultipartFile[] files, JSONObject configJson) throws IOException, JSONException {
+	private Map<String, Map<String, String>> getAggregatedData(
+		MultipartFile[] files,
+		JSONObject configJson
+	) throws IOException, JSONException {
 		Map<String, Map<String, String>> aggregatedMap = new LinkedHashMap<>();
 		for (MultipartFile file : files) {
-
 			boolean parsed = true;
 			JSONObject json = null;
 			

--- a/src/main/java/gov/cdc/foundation/security/OAuth2Configuration.java
+++ b/src/main/java/gov/cdc/foundation/security/OAuth2Configuration.java
@@ -35,7 +35,7 @@ public class OAuth2Configuration extends ResourceServerConfigurerAdapter {
 				.authorizeRequests()
 				.antMatchers(HttpMethod.OPTIONS).permitAll()
 				.antMatchers("/api/1.0/").permitAll()
-				.antMatchers(protectedURIs).access("#oauth2.hasScope('combiner')")
+				.antMatchers(protectedURIs).access("#oauth2.hasScope('fdns.combiner')")
 				.anyRequest().permitAll();
 		else
 			http

--- a/src/test/java/gov/cdc/foundation/CombinerApplicationTests.java
+++ b/src/test/java/gov/cdc/foundation/CombinerApplicationTests.java
@@ -41,7 +41,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 		"value.separator=;",
 		"logging.fluentd.host=fluentd", 
 		"logging.fluentd.port=24224",
-		"proxy.hostname=localhost",
+		"proxy.hostname=",
 		"security.oauth2.resource.user-info-uri=",
 		"security.oauth2.protected=",
 		"security.oauth2.client.client-id=",
@@ -64,7 +64,7 @@ public class CombinerApplicationTests {
 		JacksonTester.initFields(this, objectMapper);
 		
 		// Define the object URL
-		System.setProperty("OBJECT_URL", "http://fdns-ms-object:8083");
+		System.setProperty("OBJECT_URL", "http://fdns-ms-stubbing:3002/object");
 	}
 	
 	@Test

--- a/src/test/java/gov/cdc/foundation/OAuth2Test.java
+++ b/src/test/java/gov/cdc/foundation/OAuth2Test.java
@@ -2,6 +2,11 @@ package gov.cdc.foundation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +16,13 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
+import gov.cdc.helper.RequestHelper;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = {
@@ -18,11 +30,11 @@ import org.springframework.test.context.junit4.SpringRunner;
 		"value.separator=;",
 		"logging.fluentd.host=fluentd", 
 		"logging.fluentd.port=24224",
-		"proxy.hostname=localhost",
-		"security.oauth2.resource.user-info-uri=",
-		"security.oauth2.protected=/**",
-		"security.oauth2.client.client-id=",
-		"security.oauth2.client.client-secret=",
+		"proxy.hostname=",
+		"security.oauth2.resource.user-info-uri=http://fdns-ms-stubbing:3002/oauth2/token/introspect",
+		"security.oauth2.protected=/api/1.0/**",
+		"security.oauth2.client.client-id=test",
+		"security.oauth2.client.client-secret=testsecret",
 		"ssl.verifying.disable=false"})
 @AutoConfigureMockMvc
 public class OAuth2Test {
@@ -30,17 +42,67 @@ public class OAuth2Test {
 	@Autowired
 	private TestRestTemplate restTemplate;
 	private String baseUrlPath = "/api/1.0/";
-	
+	private String testToken = "Bearer testtoken";
+
+	@Before
+	public void setup() {
+		// Define the object URL
+		System.setProperty("OBJECT_URL", "http://fdns-ms-stubbing:3002/object");
+	}
+
 	@Test
-	public void indexPage() {
-		ResponseEntity<String> response = this.restTemplate.getForEntity(baseUrlPath, String.class);
+	public void testUnauthenticated() {
+		ResponseEntity<String> response = this.restTemplate.getForEntity(baseUrlPath + "config/myconfig", String.class);
+		assertThat(response.getStatusCodeValue()).isEqualTo(401);
+	}
+
+	@Test
+	public void testAthenticatedSpecific() throws Exception {
+		setScope("fdns.combiner fdns.combiner.myconfig.create");
+
+		ResponseEntity<String> response = this.restTemplate.exchange(
+			baseUrlPath + "config/myconfig",
+			HttpMethod.POST,
+			getEntity(getResourceAsString("junit/config/case-id-extractor.json"), MediaType.APPLICATION_JSON),
+			String.class
+		);
+
 		assertThat(response.getStatusCodeValue()).isEqualTo(200);
 	}
 
 	@Test
-	public void generatePage() {
-		ResponseEntity<String> response = this.restTemplate.getForEntity(baseUrlPath + "config/test", String.class);
-		assertThat(response.getStatusCodeValue()).isEqualTo(401);
+	public void testAthenticatedWildcard() throws Exception {
+		setScope("fdns.combiner fdns.combiner.*.*");
+
+		ResponseEntity<String> response = this.restTemplate.exchange(
+			baseUrlPath + "config/myconfig",
+			HttpMethod.POST,
+			getEntity(getResourceAsString("junit/config/case-id-extractor.json"), MediaType.APPLICATION_JSON),
+			String.class
+		);
+
+		assertThat(response.getStatusCodeValue()).isEqualTo(200);
 	}
 
+	private void setScope(String scope) {
+		MultiValueMap<String, String> data = new LinkedMultiValueMap<>();
+		data.add("scope", scope);
+		RequestHelper.getInstance().executePost("http://fdns-ms-stubbing:3002/oauth2/mock", data);
+	}
+
+	private String getResourceAsString(String path) throws IOException {
+		return IOUtils.toString(getResource(path));
+	}
+
+	private InputStream getResource(String path) throws IOException {
+		return getClass().getClassLoader().getResourceAsStream(path);
+	}
+
+	private HttpEntity<String> getEntity(String content, MediaType mediaType) throws IOException {
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", testToken);
+		headers.setContentType(mediaType);
+		HttpEntity<String> entity = new HttpEntity<String>(content, headers);
+		return entity;
+	}
 }


### PR DESCRIPTION
This pull request proposes a few changes:

- Changing the scopes to fall under a `fdns.*` namespace
- Adds support for CRUD operations (create, read, update and delete) and appends it at the end of the scope
- Adds support for wildcard scopes
- Adds the new https://github.com/CDCgov/fdns-ms-stubbing service for unit testing and tests OAuth 2.0 functionality